### PR TITLE
Fade keywords and align function highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- Fade structural keywords into the background and highlight function calls
 - Initial release

--- a/themes/AbyssLight-color-theme.json
+++ b/themes/AbyssLight-color-theme.json
@@ -61,29 +61,29 @@
 				"fontStyle": ""
 			}
 		},
-		{
-			"name": "Keyword",
-			"scope": "keyword",
-			"settings": {
-				"foreground": "#77aadd"
-			}
-		},
-		{
-			"name": "Storage",
-			"scope": "storage",
-			"settings": {
-				"fontStyle": "",
-				"foreground": "#77aadd"
-			}
-		},
-		{
-			"name": "Storage type",
-			"scope": "storage.type",
-			"settings": {
-				"fontStyle": "italic",
-				"foreground": "#7a4799"
-			}
-		},
+                {
+                        "name": "Keyword",
+                        "scope": "keyword",
+                        "settings": {
+                                "foreground": "#e7f3ff"
+                        }
+                },
+                {
+                        "name": "Storage",
+                        "scope": "storage",
+                        "settings": {
+                                "fontStyle": "",
+                                "foreground": "#e7f3ff"
+                        }
+                },
+                {
+                        "name": "Storage type",
+                        "scope": "storage.type",
+                        "settings": {
+                                "fontStyle": "italic",
+                                "foreground": "#e7f3ff"
+                        }
+                },
 		{
 			"name": "Class name",
 			"scope": [
@@ -137,14 +137,14 @@
 				"foreground": "#775522"
 			}
 		},
-		{
-			"name": "Library function",
-			"scope": "support.function",
-			"settings": {
-				"fontStyle": "",
-				"foreground": "#7a4799"
-			}
-		},
+                {
+                        "name": "Library function",
+                        "scope": "support.function",
+                        "settings": {
+                                "fontStyle": "",
+                                "foreground": "#775522"
+                        }
+                },
 		{
 			"name": "Library constant",
 			"scope": "support.constant",


### PR DESCRIPTION
## Summary
- Fade keywords and storage tokens into the editor background
- Highlight library function calls with the same warm brown as function names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689fa409805083278b30d841f71816c0