### PR TITLE
Fade keywords in Abyss Light theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "abyss-light" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.0.2]
+
+- Fade keywords and storage specifiers into the background so method names and
+  calls stand out.
+
+## [0.0.1]
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Abyss Light (abyss-light) README
 
+A light adaptation of the Abyss theme that hides structural keywords so that
+method names and calls are the primary visual signposts while you read code.
+
 ## How to make a custom theme
 
 * [Build your own VS Code Theme](https://learn.microsoft.com/en-us/shows/vs-code-livestreams/build-your-own-vs-code-theme) — A video tutorial that helped me get started.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-light",
   "displayName": "Abyss Light",
   "description": "A light theme that assists with focus.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.97.0"
   },

--- a/themes/AbyssLight-color-theme.json
+++ b/themes/AbyssLight-color-theme.json
@@ -1,5 +1,5 @@
 {
-	"name": "Abyss",
+        "name": "Abyss Light",
 	"tokenColors": [
 		{
 			"settings": {
@@ -61,21 +61,21 @@
 				"fontStyle": ""
 			}
 		},
-		{
-			"name": "Keyword",
-			"scope": "keyword",
-			"settings": {
-				"foreground": "#77aadd"
-			}
-		},
-		{
-			"name": "Storage",
-			"scope": "storage",
-			"settings": {
-				"fontStyle": "",
-				"foreground": "#77aadd"
-			}
-		},
+                {
+                        "name": "Keyword",
+                        "scope": "keyword",
+                        "settings": {
+                                "foreground": "#d3e2f7"
+                        }
+                },
+                {
+                        "name": "Storage",
+                        "scope": "storage",
+                        "settings": {
+                                "fontStyle": "",
+                                "foreground": "#d3e2f7"
+                        }
+                },
 		{
 			"name": "Storage type",
 			"scope": "storage.type",


### PR DESCRIPTION
## Summary
- soften keyword and storage colors so functions and calls stand out
- document theme intent in README
- bump version and update changelog

## Testing
- `node -e "const fs=require('fs');const content=fs.readFileSync('themes/AbyssLight-color-theme.json','utf8');const stripped=content.replace(/\\/\\/.*$/mg,'');JSON.parse(stripped);console.log('parse ok')}catch(e){console.error('parse fail',e.message)}"`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689fa409805083278b30d841f71816c0